### PR TITLE
Updated metadata.json so it works with Gnome 3.20

### DIFF
--- a/Random_Walls@Antares/metadata.json
+++ b/Random_Walls@Antares/metadata.json
@@ -1,5 +1,5 @@
 {
-"shell-version": ["3.14","3.16","3.18"],
+"shell-version": ["3.14","3.16","3.18","3.20"],
 "uuid": "Random_Walls@Antares",
 "url": "https://github.com/rodakorn/randwall",
 "settings-schema": "org.gnome.shell.extensions.randwall",


### PR DESCRIPTION
I have not noticed any issues with this under Gnome 3.20. Once the metadata was changed, it started to work again.
