### PR TITLE
Support Gnome > 3.32, maintain legacy version

### DIFF
--- a/Random_Walls@Antares/assets/menu.js
+++ b/Random_Walls@Antares/assets/menu.js
@@ -1,0 +1,293 @@
+const { GObject, Shell, St } = imports.gi;
+const Main = imports.ui.main;
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Convenience = Me.imports.convenience;
+const Interval = Me.imports.assets.timeout;
+const Wallpapers = Me.imports.assets.wallpapers;
+const Chooser = Me.imports.assets.pictureChooser;
+const MyConfig = Me.imports.prefs;
+const Lang = imports.lang;
+
+const PanelMenu = imports.ui.panelMenu;
+const PopupMenu = imports.ui.popupMenu;
+
+const Gettext = imports.gettext.domain('randwall');
+const _ = Gettext.gettext;
+
+const SETTINGS_FOLDER_LIST = "folder-list";
+const SETTINGS_CHANGE_MODE = "change-mode";
+const SETTINGS_HIDE_ICON = "hide-icon";
+const SETTINGS_TIMEOUT = "change-time";
+
+const CURRENT_DESK = 0;
+const CURRENT_LOCK = 1;
+const NEXT_DESK = 2;
+const NEXT_LOCK = 3;
+
+let metadata = Me.metadata;
+let settings;
+var MyTimer;
+
+var LabelWidget = GObject.registerClass(
+  class LabelWidget extends PopupMenu.PopupBaseMenuItem {
+    _init(text, type) {
+      super._init({
+        reactive: false
+      });
+
+      this._label = new St.Label({
+        text: text,
+        style_class: "labels"
+      });
+      //Add type to stylesheet.css if you want different styles
+      this._label.add_style_class_name(type);
+
+      this.add_child(this._label);
+    }
+
+    setText(text) {
+      this._label.text = text;
+    }
+  });
+
+
+var ControlButton = GObject.registerClass(
+  class ControlButton extends St.Button {
+    _init(icon, callback) {
+      this.icon = new St.Icon({
+        icon_name: icon + "-symbolic", // Get the symbol-icons.
+        icon_size: 20
+      });
+
+      super._init({
+        style_class: 'notification-icon-button control-button', // buttons styled like in Rhythmbox-notifications
+        child: this.icon
+      })
+
+      this.icon.set_style('padding: 0px');
+      this.set_style('padding: 8px'); // Put less space between buttons
+
+      if (callback != undefined || callback != null) {
+        this.connect('clicked', callback);
+      }
+    }
+
+    setIcon(icon) {
+      this.icon.icon_name = icon + '-symbolic';
+    }
+  });
+
+var ConfigControls = GObject.registerClass(
+  class ConfigControls extends PopupMenu.PopupBaseMenuItem {
+    _init() {
+      super._init({
+        reactive: false
+      });
+
+      this.box = new St.BoxLayout({
+        x_expand: "true",
+        y_expand: "true",
+        style_class: "controls",
+      });
+
+      this.box.expand = true;
+
+      this.add_child(this.box);
+      this.box.add_actor(new ControlButton("list-add", this._openConfigWidget));
+
+    }
+
+    _openConfigWidget() {
+      let _appSys = Shell.AppSystem.get_default();
+      let _gsmPrefs = _appSys.lookup_app("org.gnome.Extensions.desktop");
+      if (_gsmPrefs.get_state() == _gsmPrefs.SHELL_APP_STATE_RUNNING) {
+        _gsmPrefs.activate();
+      } else {
+        let info = _gsmPrefs.get_app_info();
+        let timestamp = global.display.get_current_time_roundtrip();
+        info.launch_uris([metadata.uuid], global.create_app_launch_context(timestamp, -1));
+      }
+    }
+  });
+
+var NextWallControls = GObject.registerClass(
+  class NextWallControls extends PopupMenu.PopupBaseMenuItem {
+    _init(wallUtils, settings) {
+      super._init({
+        reactive: false
+      });
+
+      this._wallUtils = wallUtils;
+
+      this.box = new St.BoxLayout({
+        x_expand: true,
+        y_expand: true,
+        style_class: "controls",
+      });
+
+      let currentMode = settings.get_string(SETTINGS_CHANGE_MODE);
+      if (currentMode == "different") {
+        this.box.set_style("padding-left: " + (Chooser.THUMB_WIDTH - 30) + "px;");
+      } else {
+        this.box.set_style("padding-left: " + ((Chooser.THUMB_WIDTH / 2) - 36) + "px;"); //36 = button_size*2 + padding*2
+      }
+
+      this.add_child(this.box);
+      this.box.add_actor(new ControlButton("media-playback-start", Lang.bind(this, this._changeWalls)));
+      this.box.add_actor(new ControlButton("media-playlist-shuffle", Lang.bind(this, this._newNextWalls)));
+    }
+
+    _changeWalls() {
+      if (this._wallUtils != null)
+        this._wallUtils.changeWallpapers();
+    }
+
+    _newNextWalls() {
+      if (this._wallUtils != null)
+        this._wallUtils.setNewNextAndRefresh();
+    }
+  });
+
+var ThumbPreviews = GObject.registerClass(class ThumbPreviews extends PopupMenu.PopupBaseMenuItem {
+  _init(isNextThumbs, indicator, wallUtils, _settings) {
+    super._init();
+    this._isNextThumbs = isNextThumbs;
+    this._wallUtils = wallUtils;
+    //Main Box
+    let MainBox = new St.BoxLayout({vertical: false});
+    //Label + Icon Desktop Wallpaper Box
+    let desktopBox = new St.BoxLayout({vertical: true});
+    let currentMode = _settings.get_string(SETTINGS_CHANGE_MODE);
+    let textLabel, whoami;
+    /* 1st step: Label and identifier */
+    switch (currentMode) {
+      case "different":
+      case "desktop":
+        textLabel = _("Desktop");
+        whoami = (this._isNextThumbs) ? NEXT_DESK : CURRENT_DESK;
+        break;
+      case "same":
+        textLabel = _("Desktop & Lockscreen");
+        whoami = (this._isNextThumbs) ? NEXT_DESK : CURRENT_DESK;
+        break;
+      case "lockscreen":
+        textLabel = _("Lockscreen");
+        whoami = (this._isNextThumbs) ? NEXT_LOCK : CURRENT_LOCK;
+        break;
+    }
+    desktopBox.add_child(new St.Label({text: textLabel, style_class: "label-thumb"}));
+    /* End 1st step */
+
+    /* 2nd step: Create wallIcon (only if not in lockscreen mode)*/
+    if (currentMode != "lockscreen") {
+      let filewall = wallUtils.getCurrentWall();
+      this.wallIcon = new Chooser.ThumbIcon(filewall, function () {
+        indicator.close();
+        new Chooser.PictureChooser(whoami, wallUtils).open();
+      });
+      desktopBox.add_actor(this.wallIcon);
+      MainBox.add_child(desktopBox);
+      MainBox.add_child(new St.Icon({width: 20}));
+    }
+    /* End 2nd step */
+
+    /* 3rd step: Create lockIcon (only in "different" and "lockscreen" mode*/
+    let lockwhoami = whoami;
+    switch (currentMode) {
+      case "different":
+        //whoami was NEXT or CURRENT desktop on the 1st step. Now is NEXT or CURRENT lock
+        lockwhoami = (this._isNextThumbs) ? NEXT_LOCK : CURRENT_LOCK;
+      case "lockscreen":
+        let lockBox = new St.BoxLayout({vertical: true});
+        lockBox.add_child(new St.Label({text: _("Lockscreen"), style_class: "label-thumb"}));
+        let lockwall = wallUtils.getCurrentLockWall();
+        this.lockIcon = new Chooser.ThumbIcon(lockwall, function () {
+          indicator.close();
+          new Chooser.PictureChooser(lockwhoami, wallUtils).open();
+        });
+        lockBox.add_child(this.lockIcon);
+        MainBox.add_child(lockBox);
+        break;
+    }
+    /* End 3nd step*/
+    // Add everything to the mainbox
+    this.add_actor(MainBox);
+  }
+
+  setWallThumb() {
+    let newIcon = null;
+
+    if (this._isNextThumbs)
+      newIcon = this._wallUtils.getNextWall();
+    else
+      newIcon = this._wallUtils.getCurrentWall();
+
+    this.wallIcon.set_gicon(newIcon);
+  }
+
+
+  setLockThumb() {
+    let lockIcon = null;
+
+    if (this._isNextThumbs)
+      lockIcon = this._wallUtils.getNextLockWall();
+    else
+      lockIcon = this._wallUtils.getCurrentLockWall();
+
+    this.lockIcon.set_gicon(lockIcon);
+  }
+});
+
+var RandWallMenu = GObject.registerClass(
+  class RandWallMenu extends PanelMenu.Button {
+    _init(settings, wallUtils) {
+      super._init(0.0, "randwall");
+
+      this._wallUtils = wallUtils;
+
+      let hbox = new St.BoxLayout({style_class: 'panel-status-menu-box'});
+      let gicon = imports.gi.Gio.icon_new_for_string(Me.path + "/icons/randwall-symbolic.symbolic.png");
+      let icon = new St.Icon({
+        style_class: 'system-status-icon randwall-icon',
+        gicon: gicon
+      });
+      hbox.add_child(icon);
+      hbox.add_child(PopupMenu.arrowIcon(St.Side.BOTTOM));
+      this.add_actor(hbox);
+
+      if (!this._wallUtils.isEmpty()) {
+        //Label current wallpapers
+        this.menu.addMenuItem(new LabelWidget(_("CURRENT"), "info"));
+        // Current Walls thumbs
+        this.currentThumbs = new ThumbPreviews(false, this, wallUtils, settings);
+        this.menu.addMenuItem(this.currentThumbs);
+        // Separator
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        //Label current wallpapers
+        this.menu.addMenuItem(new LabelWidget(_("NEXT"), "info"));
+        // Next Walls thumbs
+        this.nextThumbs = new ThumbPreviews(true, this, wallUtils, settings);
+        this.menu.addMenuItem(this.nextThumbs);
+        // Separator
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        //Controles
+        let control = new NextWallControls(wallUtils, settings);
+        this.menu.addMenuItem(control);
+      } else {
+        this.menu.addMenuItem(new LabelWidget(_("No images found!"), "error"));
+        this.menu.addMenuItem(new LabelWidget(_("Please, add some folders with images"), "info"));
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        this.menu.addMenuItem(new ConfigControls());
+      }
+    }
+
+    _changeBackgrounds() {
+      this._wallUtils.changeWallpapers();
+      //update thumbs
+      this.refreshThumbs();
+    }
+
+    close() {
+      this.menu.close();
+    }
+  });

--- a/Random_Walls@Antares/assets/timeout.js
+++ b/Random_Walls@Antares/assets/timeout.js
@@ -10,6 +10,7 @@ var MyTimer = class MyTimer {
   constructor() {
     this._settings = Convenience.getSettings();
     this._timeout = this._settings.get_int(SETTINGS_TIMEOUT) * 60000;
+    this._timerId = null;
     // Listen to changes and restart with new timeout.
     this._settings.connect('changed::' + SETTINGS_TIMEOUT, Lang.bind(this, function (value) {
       let newValue = value.get_int(SETTINGS_TIMEOUT);

--- a/Random_Walls@Antares/assets/wallpapers.js
+++ b/Random_Walls@Antares/assets/wallpapers.js
@@ -138,6 +138,11 @@ var WallUtils = class WallUtils {
   }
 
   changeWallpapers() {
+    // silence warnings if we removed all directories
+    if (!this._dirs) {
+      return;
+    }
+
     let currentMode = this._settings.get_string(SETTINGS_CHANGE_MODE);
     //DESKTOP CHANGE: Always except if we are in lockscreen mode
     if (currentMode != 'lockscreen')
@@ -173,6 +178,11 @@ var WallUtils = class WallUtils {
   }
 
   setNewNextAndRefresh() {
+    // silence warnings if we removed all directories
+    if (!this._dirs) {
+      return;
+    }
+
     let currentMode = this._settings.get_string(SETTINGS_CHANGE_MODE);
 
     this._nextWall = this.getRandomPicture();
@@ -198,7 +208,7 @@ var WallUtils = class WallUtils {
       fileEnum = null;
     }
     if (fileEnum !== null) {
-      let info, child;
+      let info;
       while ((info = fileEnum.next_file(null)) != null) {
         let child = fileEnum.get_child(info);
         //Check if is a regular file
@@ -236,8 +246,6 @@ var WallUtils = class WallUtils {
   isEmpty() {
     return this._dirs == null;
   }
-
-
 }
 
 var getScreenAspectRatio = function () {

--- a/Random_Walls@Antares/extension.js
+++ b/Random_Walls@Antares/extension.js
@@ -4,310 +4,27 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
 const Interval = Me.imports.assets.timeout;
 const Wallpapers = Me.imports.assets.wallpapers;
-const Chooser = Me.imports.assets.pictureChooser;
-const MyConfig = Me.imports.prefs;
 const Lang = imports.lang;
-const Tweener = imports.tweener.tweener;
+const Config = imports.misc.config;
 
+let shellMinorVersion = parseInt(Config.PACKAGE_VERSION.split('.')[1]);
+
+let RandWallMenu;
+let wallUtils;
+
+if (shellMinorVersion > 30) {
+  RandWallMenu = Me.imports.assets.menu.RandWallMenu;
+} else {
+  RandWallMenu = Me.imports.legacy.menu.RandWallMenu
+}
 
 const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;
-
-const Gettext = imports.gettext.domain('randwall');
-const _ = Gettext.gettext;
 
 const SETTINGS_FOLDER_LIST = "folder-list";
 const SETTINGS_CHANGE_MODE = "change-mode";
 const SETTINGS_HIDE_ICON = "hide-icon";
 const SETTINGS_TIMEOUT = "change-time";
-
-const CURRENT_DESK = 0;
-const CURRENT_LOCK = 1;
-const NEXT_DESK = 2;
-const NEXT_LOCK = 3;
-
-let metadata = Me.metadata;
-let settings;
-var MyTimer;
-let wallUtils;
-
-const LabelWidget = GObject.registerClass(
-  class LabelWidget extends PopupMenu.PopupBaseMenuItem {
-    _init(text, type) {
-      super._init({
-        reactive: false
-      });
-
-      this._label = new St.Label({
-        text: text,
-        style_class: "labels"
-      });
-      //Add type to stylesheet.css if you want different styles
-      this._label.add_style_class_name(type);
-
-      this.add_child(this._label);
-    }
-
-    setText(text) {
-      this._label.text = text;
-    }
-  });
-
-
-const ControlButton = GObject.registerClass(
-  class ControlButton extends St.Button {
-    _init(icon, callback) {
-      this.icon = new St.Icon({
-        icon_name: icon + "-symbolic", // Get the symbol-icons.
-        icon_size: 20
-      });
-
-      super._init({
-        style_class: 'notification-icon-button control-button', // buttons styled like in Rhythmbox-notifications
-        child: this.icon
-      })
-
-      this.icon.set_style('padding: 0px');
-      this.set_style('padding: 8px'); // Put less space between buttons
-
-      if (callback != undefined || callback != null) {
-        this.connect('clicked', callback);
-      }
-    }
-
-    setIcon(icon) {
-      this.icon.icon_name = icon + '-symbolic';
-    }
-  });
-
-const ConfigControls = GObject.registerClass(
-  class ConfigControls extends PopupMenu.PopupBaseMenuItem {
-    _init() {
-      super._init({
-        reactive: false
-      });
-
-      this.box = new St.BoxLayout({
-        x_expand: "true",
-        y_expand: "true",
-        style_class: "controls",
-      });
-
-      this.box.expand = true;
-
-      this.add_child(this.box);
-      this.box.add_actor(new ControlButton("list-add", this._openConfigWidget));
-
-    }
-
-    _openConfigWidget() {
-      let _appSys = Shell.AppSystem.get_default();
-      let _gsmPrefs = _appSys.lookup_app("org.gnome.Extensions.desktop");
-      if (_gsmPrefs.get_state() == _gsmPrefs.SHELL_APP_STATE_RUNNING) {
-        _gsmPrefs.activate();
-      } else {
-        let info = _gsmPrefs.get_app_info();
-        let timestamp = global.display.get_current_time_roundtrip();
-        info.launch_uris([metadata.uuid], global.create_app_launch_context(timestamp, -1));
-      }
-    }
-  });
-
-const NextWallControls = GObject.registerClass(
-  class NextWallControls extends PopupMenu.PopupBaseMenuItem {
-    _init() {
-      super._init({
-        reactive: false
-      });
-
-      this.box = new St.BoxLayout({
-        x_expand: true,
-        y_expand: true,
-        style_class: "controls",
-      });
-
-      let currentMode = _settings.get_string(SETTINGS_CHANGE_MODE);
-      if (currentMode == "different") {
-        this.box.set_style("padding-left: " + (Chooser.THUMB_WIDTH - 30) + "px;");
-      } else {
-        this.box.set_style("padding-left: " + ((Chooser.THUMB_WIDTH / 2) - 36) + "px;"); //36 = button_size*2 + padding*2
-      }
-
-      this.add_child(this.box);
-      this.box.add_actor(new ControlButton("media-playback-start", this._changeWalls));
-      this.box.add_actor(new ControlButton("media-playlist-shuffle", this._newNextWalls));
-
-    }
-
-    _changeWalls() {
-      if (wallUtils != null)
-        wallUtils.changeWallpapers();
-    }
-
-    _newNextWalls() {
-      if (wallUtils != null)
-        wallUtils.setNewNextAndRefresh();
-    }
-  });
-
-const ThumbPreviews = GObject.registerClass(class ThumbPreviews extends PopupMenu.PopupBaseMenuItem {
-  _init(isNextThumbs) {
-    super._init();
-    this._isNextThumbs = isNextThumbs;
-    //Main Box
-    let MainBox = new St.BoxLayout({vertical: false});
-    //Label + Icon Desktop Wallpaper Box
-    let desktopBox = new St.BoxLayout({vertical: true});
-    let currentMode = _settings.get_string(SETTINGS_CHANGE_MODE);
-    let textLabel, whoami;
-    /* 1st step: Label and identifier */
-    switch (currentMode) {
-      case "different":
-      case "desktop":
-        textLabel = _("Desktop");
-        whoami = (this._isNextThumbs) ? NEXT_DESK : CURRENT_DESK;
-        break;
-      case "same":
-        textLabel = _("Desktop & Lockscreen");
-        whoami = (this._isNextThumbs) ? NEXT_DESK : CURRENT_DESK;
-        break;
-      case "lockscreen":
-        textLabel = _("Lockscreen");
-        whoami = (this._isNextThumbs) ? NEXT_LOCK : CURRENT_LOCK;
-        break;
-    }
-    desktopBox.add_child(new St.Label({text: textLabel, style_class: "label-thumb"}));
-    /* End 1st step */
-
-    /* 2nd step: Create wallIcon (only if not in lockscreen mode)*/
-    if (currentMode != "lockscreen") {
-      let filewall = wallUtils.getCurrentWall();
-      this.wallIcon = new Chooser.ThumbIcon(filewall, function () {
-        _indicator.close();
-        new Chooser.PictureChooser(whoami, wallUtils).open();
-      });
-      desktopBox.add_actor(this.wallIcon);
-      MainBox.add_child(desktopBox);
-      MainBox.add_child(new St.Icon({width: 20}));
-    }
-    /* End 2nd step */
-
-    /* 3rd step: Create lockIcon (only in "different" and "lockscreen" mode*/
-    let lockwhoami = whoami;
-    switch (currentMode) {
-      case "different":
-        //whoami was NEXT or CURRENT desktop on the 1st step. Now is NEXT or CURRENT lock
-        lockwhoami = (this._isNextThumbs) ? NEXT_LOCK : CURRENT_LOCK;
-      case "lockscreen":
-        let lockBox = new St.BoxLayout({vertical: true});
-        lockBox.add_child(new St.Label({text: _("Lockscreen"), style_class: "label-thumb"}));
-        let lockwall = wallUtils.getCurrentLockWall();
-        this.lockIcon = new Chooser.ThumbIcon(lockwall, function () {
-          _indicator.close();
-          new Chooser.PictureChooser(lockwhoami, wallUtils).open();
-        });
-        lockBox.add_child(this.lockIcon);
-        MainBox.add_child(lockBox);
-        break;
-    }
-    /* End 3nd step*/
-    // Add everything to the mainbox
-    this.add_actor(MainBox);
-  }
-
-  setWallThumb() {
-    let newIcon = null;
-    if (this._isNextThumbs)
-      newIcon = wallUtils.getNextWall();
-    else
-      newIcon = wallUtils.getCurrentWall();
-    Tweener.addTween(this.wallIcon, {
-      opacity: 0,
-      time: 1,
-      transition: 'easeOutQuad',
-      onCompleteParams: [this.wallIcon, newIcon],
-      onComplete: function (thumb, icon) {
-        thumb.set_gicon(icon);
-      }
-    });
-    Tweener.addTween(this.wallIcon, {opacity: 255, delay: 1.3, time: 1, transition: 'easeOutQuad'});
-  }
-
-
-  setLockThumb() {
-    let lockIcon = null;
-    if (this._isNextThumbs)
-      lockIcon = wallUtils.getNextLockWall();
-    else
-      lockIcon = wallUtils.getCurrentLockWall();
-    Tweener.addTween(this.lockIcon, {
-      opacity: 0,
-      time: 1,
-      transition: 'easeOutQuad',
-      onCompleteParams: [this.lockIcon, lockIcon],
-      onComplete: function (thumb, icon) {
-        thumb.set_gicon(icon);
-      }
-    });
-    Tweener.addTween(this.lockIcon, {opacity: 255, delay: 1.3, time: 1, transition: 'easeOutQuad'});
-  }
-});
-
-const RandWallMenu = GObject.registerClass(
-  class RandWallMenu extends PanelMenu.Button {
-    _init() {
-      super._init(0.0, "randwall");
-      // this.mainButton = new PanelMenu.Button(0.0, "randwall");
-      // this.menu = this.mainButton.menu;
-      // this.actor = this.mainButton.actor;
-      let hbox = new St.BoxLayout({style_class: 'panel-status-menu-box'});
-      let gicon = imports.gi.Gio.icon_new_for_string(Me.path + "/icons/randwall-symbolic.symbolic.png");
-      let icon = new St.Icon({
-        style_class: 'system-status-icon randwall-icon',
-        gicon: gicon
-      });
-      hbox.add_child(icon);
-      hbox.add_child(PopupMenu.arrowIcon(St.Side.BOTTOM));
-      this.add_actor(hbox);
-
-      if (!wallUtils.isEmpty()) {
-        //Label current wallpapers
-        this.menu.addMenuItem(new LabelWidget(_("CURRENT"), "info"));
-        // Current Walls thumbs
-        this.currentThumbs = new ThumbPreviews(false);
-        this.menu.addMenuItem(this.currentThumbs);
-        // Separator
-        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-        //Label current wallpapers
-        this.menu.addMenuItem(new LabelWidget(_("NEXT"), "info"));
-        // Next Walls thumbs
-        this.nextThumbs = new ThumbPreviews(true);
-        this.menu.addMenuItem(this.nextThumbs);
-        // Separator
-        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-        //Controles
-        let control = new NextWallControls();
-        this.menu.addMenuItem(control);
-      } else {
-        this.menu.addMenuItem(new LabelWidget(_("No images found!"), "error"));
-        this.menu.addMenuItem(new LabelWidget(_("Please, add some folders with images"), "info"));
-        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-        this.menu.addMenuItem(new ConfigControls());
-      }
-
-    }
-
-    _changeBackgrounds() {
-      wallUtils.changeWallpapers();
-      //update thumbs
-      this.refreshThumbs();
-    }
-
-    close() {
-      this.menu.close();
-    }
-  });
-
 
 function init(metadata) {
   _settings = Convenience.getSettings();
@@ -332,7 +49,7 @@ let _indicator;
 let _settings;
 
 function enable() {
-  _indicator = new RandWallMenu(_settings);
+  _indicator = new RandWallMenu(_settings, wallUtils);
 
   wallUtils.setIndicator(_indicator);
   if (!wallUtils.isEmpty() && this.MyTimer && _settings.get_int(SETTINGS_TIMEOUT) != 0) {
@@ -355,7 +72,7 @@ function applyChanges() {
 
   _indicator.destroy();
   wallUtils = new Wallpapers.WallUtils(_settings);
-  _indicator = new RandWallMenu(_settings);
+  _indicator = new RandWallMenu(_settings, wallUtils);
   wallUtils.setIndicator(_indicator);
   let hideIcon = _settings.get_boolean(SETTINGS_HIDE_ICON);
   if (!hideIcon)

--- a/Random_Walls@Antares/legacy/menu.js
+++ b/Random_Walls@Antares/legacy/menu.js
@@ -1,0 +1,279 @@
+const { GObject, Shell, St } = imports.gi;
+const Main = imports.ui.main;
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Convenience = Me.imports.convenience;
+const Interval = Me.imports.assets.timeout;
+const Wallpapers = Me.imports.assets.wallpapers;
+const Chooser = Me.imports.legacy.pictureChooser;
+const MyConfig = Me.imports.prefs;
+const Lang = imports.lang;
+
+const PanelMenu = imports.ui.panelMenu;
+const PopupMenu = imports.ui.popupMenu;
+
+const Gettext = imports.gettext.domain('randwall');
+const _ = Gettext.gettext;
+
+const SETTINGS_FOLDER_LIST = "folder-list";
+const SETTINGS_CHANGE_MODE = "change-mode";
+const SETTINGS_HIDE_ICON = "hide-icon";
+const SETTINGS_TIMEOUT = "change-time";
+
+const CURRENT_DESK = 0;
+const CURRENT_LOCK = 1;
+const NEXT_DESK = 2;
+const NEXT_LOCK = 3;
+
+let metadata = Me.metadata;
+let settings;
+var MyTimer;
+
+var LabelWidget = class LabelWidget extends PopupMenu.PopupBaseMenuItem {
+  constructor(text, type) {
+    super({
+      reactive: false
+    });
+
+    this._label = new St.Label({
+      text: text,
+      style_class: "labels"
+    });
+    //Add type to stylesheet.css if you want different styles
+    this._label.add_style_class_name(type);
+
+    this.actor.add_child(this._label);
+  }
+
+  setText(text) {
+    this._label.text = text;
+  }
+};
+
+var ControlButton = class ControlButton {
+  constructor(icon, callback) {
+    this.icon = new St.Icon({
+      icon_name: icon + "-symbolic", // Get the symbol-icons.
+      icon_size: 20
+    });
+
+    this.actor = new St.Button({
+      style_class: 'notification-icon-button control-button', // buttons styled like in Rhythmbox-notifications
+      child: this.icon
+    });
+    this.icon.set_style('padding: 0px');
+    this.actor.set_style('padding: 8px'); // Put less space between buttons
+
+    if (callback != undefined || callback != null) {
+      this.actor.connect('clicked', callback);
+    }
+  }
+
+  setIcon(icon) {
+    this.icon.icon_name = icon + '-symbolic';
+  }
+};
+
+const ConfigControls = class ConfigControls extends PopupMenu.PopupBaseMenuItem {
+  constructor() {
+    super({
+      reactive: false
+    });
+
+    this.box = new St.BoxLayout({
+      style_class: "controls",
+    });
+
+    this.actor.add(this.box, {expand: true});
+    this.box.add_actor(new ControlButton("list-add", this._openConfigWidget).actor);
+
+  }
+
+  _openConfigWidget() {
+    let _appSys = Shell.AppSystem.get_default();
+    let _gsmPrefs = _appSys.lookup_app('gnome-shell-extension-prefs.desktop');
+    if (_gsmPrefs.get_state() == _gsmPrefs.SHELL_APP_STATE_RUNNING) {
+      _gsmPrefs.activate();
+    } else {
+      let info = _gsmPrefs.get_app_info();
+      let timestamp = global.display.get_current_time_roundtrip();
+      info.launch_uris([metadata.uuid], global.create_app_launch_context(timestamp, -1));
+    }
+  }
+};
+
+var NextWallControls = class NextWallControls extends PopupMenu.PopupBaseMenuItem {
+  constructor(wallUtils, settings) {
+    super({
+      reactive: false
+    });
+
+    this._wallUtils = wallUtils;
+
+    this.box = new St.BoxLayout({
+      style_class: "controls",
+    });
+
+    let currentMode = settings.get_string(SETTINGS_CHANGE_MODE);
+    if (currentMode == "different") {
+      this.box.set_style("padding-left: " + (Chooser.THUMB_WIDTH - 30) + "px;");
+    } else
+      this.box.set_style("padding-left: " + ((Chooser.THUMB_WIDTH / 2) - 36) + "px;"); //36 = button_size*2 + padding*2
+
+    this.actor.add(this.box, {expand: true});
+    this.box.add_actor(new ControlButton("media-playback-start", Lang.bind(this, this._changeWalls)).actor);
+    this.box.add_actor(new ControlButton("media-playlist-shuffle", Lang.bind(this, this._newNextWalls)).actor);
+
+  }
+
+  _changeWalls() {
+    if (this._wallUtils != null)
+      this._wallUtils.changeWallpapers();
+  }
+
+  _newNextWalls() {
+    if (this._wallUtils != null)
+      this._wallUtils.setNewNextAndRefresh();
+  }
+};
+
+var thumbPreviews = class thumbPreviews extends PopupMenu.PopupBaseMenuItem {
+  constructor(isNextThumbs, indicator, wallUtils, _settings) {
+    super();
+    this._isNextThumbs = isNextThumbs;
+    this._wallUtils = wallUtils;
+
+    //Main Box
+    let MainBox = new St.BoxLayout({vertical: false});
+    //Label + Icon Desktop Wallpaper Box
+    let desktopBox = new St.BoxLayout({vertical: true});
+    let currentMode = _settings.get_string(SETTINGS_CHANGE_MODE);
+    let textLabel, whoami;
+    /* 1st step: Label and identifier */
+    switch (currentMode) {
+      case "different":
+      case "desktop":
+        textLabel = _("Desktop");
+        whoami = (this._isNextThumbs) ? NEXT_DESK : CURRENT_DESK;
+        break;
+      case "same":
+        textLabel = _("Desktop & Lockscreen");
+        whoami = (this._isNextThumbs) ? NEXT_DESK : CURRENT_DESK;
+        break;
+      case "lockscreen":
+        textLabel = _("Lockscreen");
+        whoami = (this._isNextThumbs) ? NEXT_LOCK : CURRENT_LOCK;
+        break;
+    }
+    desktopBox.add_child(new St.Label({text: textLabel, style_class: "label-thumb"}));
+    /* End 1st step */
+
+    /* 2nd step: Create wallIcon (only if not in lockscreen mode)*/
+    if (currentMode != "lockscreen") {
+      let filewall = wallUtils.getCurrentWall();
+      this.wallIcon = new Chooser.ThumbIcon(filewall, function () {
+        indicator.close();
+        new Chooser.PictureChooser(whoami, wallUtils).open();
+      });
+      desktopBox.add_actor(this.wallIcon.actor);
+      MainBox.add_child(desktopBox);
+      MainBox.add_child(new St.Icon({width: 20}));
+    }
+    /* End 2nd step */
+
+    /* 3rd step: Create lockIcon (only in "different" and "lockscreen" mode*/
+    let lockwhoami = whoami;
+    switch (currentMode) {
+      case "different":
+        //whoami was NEXT or CURRENT desktop on the 1st step. Now is NEXT or CURRENT lock
+        lockwhoami = (this._isNextThumbs) ? NEXT_LOCK : CURRENT_LOCK;
+      case "lockscreen":
+        let lockBox = new St.BoxLayout({vertical: true});
+        lockBox.add_child(new St.Label({text: _("Lockscreen"), style_class: "label-thumb"}));
+        let lockwall = wallUtils.getCurrentLockWall();
+        this.lockIcon = new Chooser.ThumbIcon(lockwall, function () {
+          indicator.close();
+          new Chooser.PictureChooser(lockwhoami, wallUtils).open();
+        });
+        lockBox.add_child(this.lockIcon.actor);
+        MainBox.add_child(lockBox);
+        break;
+    }
+    /* End 3nd step*/
+    // Add everything to the mainbox
+    this.actor.add_actor(MainBox);
+  }
+
+  setWallThumb() {
+    let newIcon = null;
+    if (this._isNextThumbs)
+      newIcon = this._wallUtils.getNextWall();
+    else
+      newIcon = this._wallUtils.getCurrentWall();
+
+    this.wallIcon.set_gicon(newIcon);
+  }
+
+
+  setLockThumb() {
+    let lockIcon = null;
+    if (this._isNextThumbs)
+      lockIcon = this._wallUtils.getNextLockWall();
+    else
+      lockIcon = this._wallUtils.getCurrentLockWall();
+
+    this.lockIcon.set_gicon(lockIcon);
+  }
+};
+
+var RandWallMenu = class RandWallMenu extends PanelMenu.Button {
+  _init(settings, wallUtils) {
+    super._init(0.0, "randwall");
+
+    this._wallUtils = wallUtils;
+
+    let hbox = new St.BoxLayout({style_class: 'panel-status-menu-box'});
+    let gicon = imports.gi.Gio.icon_new_for_string(Me.path + "/icons/randwall-symbolic.symbolic.png");
+    let icon = new St.Icon({
+      style_class: 'system-status-icon randwall-icon',
+      gicon: gicon
+    });
+    hbox.add_child(icon);
+    hbox.add_child(PopupMenu.arrowIcon(St.Side.BOTTOM));
+    this.actor.add_actor(hbox);
+
+    if (!wallUtils.isEmpty()) {
+      //Label current wallpapers
+      this.menu.addMenuItem(new LabelWidget(_("CURRENT"), "info"));
+      // Current Walls thumbs
+      this.currentThumbs = new thumbPreviews(false, this, wallUtils, settings);
+      this.menu.addMenuItem(this.currentThumbs);
+      // Separator
+      this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+      //Label current wallpapers
+      this.menu.addMenuItem(new LabelWidget(_("NEXT"), "info"));
+      // Next Walls thumbs
+      this.nextThumbs = new thumbPreviews(true, this, wallUtils, settings);
+      this.menu.addMenuItem(this.nextThumbs);
+      // Separator
+      this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+      //Controles
+      let control = new NextWallControls(wallUtils, settings);
+      this.menu.addMenuItem(control);
+    } else {
+      this.menu.addMenuItem(new LabelWidget(_("No images found!"), "error"));
+      this.menu.addMenuItem(new LabelWidget(_("Please, add some folders with images"), "info"));
+      this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+      this.menu.addMenuItem(new ConfigControls());
+    }
+  }
+
+  _changeBackgrounds() {
+    this._wallUtils.changeWallpapers();
+    //update thumbs
+    this.refreshThumbs();
+  }
+
+  close() {
+    this.menu.close();
+  }
+};

--- a/Random_Walls@Antares/prefs.js
+++ b/Random_Walls@Antares/prefs.js
@@ -62,19 +62,25 @@ const RandWallSettingsWidget = new GObject.Class({
 		let range = this._settings.get_range(SETTINGS_CHANGE_MODE);
 		let currentMode = this._settings.get_string(SETTINGS_CHANGE_MODE);
 		let modes = range.deep_unpack()[1].deep_unpack();
+		
 		let grid = new Gtk.Grid({ orientation: Gtk.Orientation.VERTICAL,row_spacing: 6,column_spacing: 6,margin_top: 6, margin_left: 20 });
-		for (var i = 0; i < modes.length; i++) {
+		for (let i = 0; i < modes.length; i++) {
             let mode = modes[i];
             let label = modeLabels[mode];
             if (!label) {
                log('Unhandled option "%s" for lock-mode'.format(mode));
                continue;
             }
-
             radio = new Gtk.RadioButton({ active: currentMode == mode,
                                           label: label,
-                                          group: radio });
-            grid.add(radio);
+										  group: radio });
+										  
+			grid.add(radio);
+			
+			if (currentMode === mode) {
+				radio.set_active(true);
+			}
+
             radio.connect('toggled', Lang.bind(this, function(button) {
                 if (button.active)
                     this._settings.set_string(SETTINGS_CHANGE_MODE, mode);
@@ -88,7 +94,10 @@ const RandWallSettingsWidget = new GObject.Class({
 		//Hide Icon
 		let gHBoxHideIcon = new Gtk.HBox({margin:10, spacing: 20, hexpand: true});
 		gHBoxHideIcon.add(new Gtk.Label({label: _("Hide Icon"),halign: Gtk.Align.START, margin: 10}));
-		let iconSwitch = new Gtk.Switch({halign: Gtk.Align.END});
+		let iconSwitch = new Gtk.Switch({
+			active: this._settings.get_boolean(SETTINGS_HIDE_ICON),
+			halign: Gtk.Align.END
+		});
 		gHBoxHideIcon.add(iconSwitch);
 		this.add(gHBoxHideIcon);
 		this.add(new Gtk.HSeparator());
@@ -146,8 +155,6 @@ const RandWallSettingsWidget = new GObject.Class({
 		
         this._changedPermitted = true;
         this._refresh();
-
-
     },
     
   

--- a/Random_Walls@Antares/stylesheet.css
+++ b/Random_Walls@Antares/stylesheet.css
@@ -35,7 +35,7 @@
 }
 
 .controls {
-    	spacing: 10px;
+    spacing: 10px;
 	padding-top: 0px;
 	padding-left: 0px;
 }
@@ -100,5 +100,3 @@
 	padding-right: 5px;
 	color: darkgrey;
 }
-
-


### PR DESCRIPTION
Adds support for gnome >3.32:
- classes are now `GObject.registerClass`...
- remove references to `this.actor`
- update certain instances of `add` (properties have to be on the class itself)

Separate legacy code for support of older versions
- older version of code moved to `legacy`
- `wallUtils` and `settings` are now passed around (as opposed to in `extension.js`
- replace `this.parent()` with calls to `super.`

Other changes
- small changes to styling, height
- remove tweeny. It was causing a number of warnings (lingering code), and completely broke under debian 10 (3.30)
- preferences window actually reflect selected preferences

Tested in:
- Arch Linux (Gnome 3.38)
- Debian 10.7 (Gnome 3.30)
- Fedora 32 (3.36)
- Ubuntu 18.04 (3.28)
- Ubuntu 20.04 (3.36)

Issues:
- Under older versions of gnome, there would be errors logged whenever the background changes (tweeny and objects that were referenced no longer being referenced). This doesn't seem to impact the performance of the extension, but I am not entirely sure what is happening. I'll examine this later, but just want this out for preliminary review

![gnome-debian-error](https://user-images.githubusercontent.com/17521368/102745821-c799ee80-4354-11eb-9b8c-abd00cf11427.png)